### PR TITLE
Installed Rivescript plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -201,6 +201,11 @@
       "resolved": "https://registry.npmjs.org/botpress-messenger/-/botpress-messenger-2.2.9.tgz",
       "integrity": "sha512-GUh95HQqEhYNeN8YpQwxcDGmMSwFYMNVwzoTRF+UrF7kNvyCQVfpne7U1U+/+QxWvwCi2ybQLA/gP4a00ENz1w=="
     },
+    "botpress-rivescript": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/botpress-rivescript/-/botpress-rivescript-2.0.7.tgz",
+      "integrity": "sha1-02ebsa5jOmsGFamffu+AduNAS1Y="
+    },
     "botpress-version-manager": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/botpress-version-manager/-/botpress-version-manager-1.0.4.tgz",
@@ -760,6 +765,16 @@
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
     },
+    "fs-extra": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA="
+    },
+    "fs-readdir-recursive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
+      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -799,6 +814,11 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948="
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -1109,6 +1129,11 @@
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
     },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug="
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -1157,6 +1182,11 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk="
     },
     "knex": {
       "version": "0.12.9",
@@ -1859,6 +1889,16 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
         }
       }
+    },
+    "rivescript": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/rivescript/-/rivescript-1.17.2.tgz",
+      "integrity": "sha1-HkLwIEE76b6KeFRvJkK+iWWwls4="
+    },
+    "rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
     },
     "safe-buffer": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -6,17 +6,16 @@
   "dependencies": {
     "botpress": "1.x",
     "botpress-messenger": "^2.2.9",
+    "botpress-rivescript": "^2.0.7",
     "botpress-web": "1.x"
   },
   "scripts": {
     "start": "botpress start",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-
   "engines": {
-  "node": ">= 8.0"
+    "node": ">= 8.0"
   },
-  
   "author": "Lisa Williams and Michelle Ferrier",
   "license": "Botpress Proprietary License"
 }


### PR DESCRIPTION
Ran `botpress install rivescript` and got the following response:

```
[botpress] 	 please wait, we are trying to install your new modules...
[botpress] 	 Installing modules: botpress-rivescript
[botpress] 	 ERR npm
[botpress] 	 ERR  WARN react-audio-player@0.5.0 requires a peer of react@15.x but none was installed.
npm WARN react-audio-player@0.5.0 requires a peer of react-dom@15.x but none was installed.
npm WARN react-codemirror@1.0.0 requires a peer of react@>=15.5 <16 but none was installed.
npm WARN react-codemirror@1.0.0 requires a peer of react-dom@>=15.5 <16 but none was installed.
npm WARN react-player@0.18.0 requires a peer of react@* but none was installed.
npm
[botpress] 	 ERR  WARN trollbustersbot@0.0.1 No repository field.
npm WARN trollbustersbot@0.0.1 license should be a valid SPDX license expression

[botpress] 	 added 8 packages in 39.62s

[botpress] 	 OK Modules successfully installed

```
Restarted the Botpress server and reloaded the page on localhost:3000

Rivepress module now appears in left rail

Visited bot FB page and confirmed that bot still worked after module
installation.

Responds to Issue #10